### PR TITLE
avoid using dependencies with published CVE's

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.49</version>
+            <version>1.56</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.49</version>
+            <version>1.56</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -63,12 +63,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.3</version>
+            <version>4.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.3.2</version>
+            <version>4.4.6</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
@@ -274,6 +274,19 @@
                             <finalName>ctlog-${project.version}-with-deps</finalName>
                             <minimizeJar>true</minimizeJar>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>1.4.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This lets you run "mvn verify" in order to check if there is any published CVE's for the dependencies that the project uses.

Running that produces this output:

```
One or more dependencies were identified with known vulnerabilities in ctlog:

httpclient-4.3.3.jar (cpe:/a:apache:httpclient:4.3.3, org.apache.httpcomponents:httpclient:4.3.3) : CVE-2015-5262, CVE-2014-3577
bcprov-jdk15on-1.49.jar (cpe:/a:bouncycastle:bouncy-castle-crypto-package:1.49, cpe:/a:bouncycastle:bouncy_castle_crypto_package:1.49, org.bouncycastle:bcprov-jdk15on:1.49) : CVE-2015-7940
```

I have gone over the CVE's and are quite sure that they don't affect the project in any way, so I have not tried to do any responsible disclosure (as I don't believe that there is an actual security problem here).

It's also possible to configure the plugin to fail the build if anything is found, I don't have a strong opinion about if that's a good strategy.

Included in the pull request are upgrades of the affected libraries, so that the plugin no longer gives any output.

(I messed up where i branched from in the previous pull request, so this is a remake of that one)