### PR TITLE
Support for networks requiring a proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,6 @@
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>5.0.6.RELEASE</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.0.6.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/certificatetransparency/ctlog/comm/HttpInvoker.java
+++ b/src/main/java/org/certificatetransparency/ctlog/comm/HttpInvoker.java
@@ -11,6 +11,10 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
 /** Simple delegator to HttpClient, so it can be mocked */
 public class HttpInvoker {
@@ -35,7 +39,7 @@ public class HttpInvoker {
 
   /**
    * Make an HTTP POST method call to the given URL with the provided JSON payload. This method uses
-   * useSystemProperties() option from HttpClientBuilder.
+   * RestTemplate, which uses the system proxy automatically.
    *
    * @param url URL for POST method
    * @param jsonPayload Serialized JSON payload.

--- a/src/main/java/org/certificatetransparency/ctlog/comm/HttpInvoker.java
+++ b/src/main/java/org/certificatetransparency/ctlog/comm/HttpInvoker.java
@@ -46,16 +46,15 @@ public class HttpInvoker {
    * @return Server's response body.
    */
   public String makePostRequestAutoProxy(String url, String jsonPayload) {
-    RestTemplate restTemplate = new RestTemplate();
+    try (CloseableHttpClient httpClient = HttpClientBuilder.create().useSystemProperties().build()) {
+      HttpPost post = new HttpPost(url);
+      post.setEntity(new StringEntity(jsonPayload, "utf-8"));
+      post.addHeader("Content-Type", "application/json; charset=utf-8");
 
-    HttpHeaders headers = new HttpHeaders();
-    headers.add("Content-Type", "application/json; charset=utf-8");
-
-    HttpEntity<String> entity = new HttpEntity<>(jsonPayload, headers);
-
-    ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
-
-    return response.getBody();
+      return httpClient.execute(post, new BasicResponseHandler());
+    } catch (IOException e) {
+      throw new LogCommunicationException("Error making POST request to " + url, e);
+    }
   }
 
   /**

--- a/src/main/java/org/certificatetransparency/ctlog/comm/HttpInvoker.java
+++ b/src/main/java/org/certificatetransparency/ctlog/comm/HttpInvoker.java
@@ -11,6 +11,10 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
 /** Simple delegator to HttpClient, so it can be mocked */
 public class HttpInvoker {
@@ -31,6 +35,27 @@ public class HttpInvoker {
     } catch (IOException e) {
       throw new LogCommunicationException("Error making POST request to " + url, e);
     }
+  }
+
+  /**
+   * Make an HTTP POST method call to the given URL with the provided JSON payload. This method uses
+   * RestTemplate, which uses the system proxy automatically.
+   *
+   * @param url URL for POST method
+   * @param jsonPayload Serialized JSON payload.
+   * @return Server's response body.
+   */
+  public String makePostRequestAutoProxy(String url, String jsonPayload) {
+    RestTemplate restTemplate = new RestTemplate();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Content-Type", "application/json; charset=utf-8");
+
+    HttpEntity<String> entity = new HttpEntity<>(jsonPayload, headers);
+
+    ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+
+    return response.getBody();
   }
 
   /**

--- a/src/main/java/org/certificatetransparency/ctlog/comm/HttpInvoker.java
+++ b/src/main/java/org/certificatetransparency/ctlog/comm/HttpInvoker.java
@@ -11,10 +11,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
 
 /** Simple delegator to HttpClient, so it can be mocked */
 public class HttpInvoker {
@@ -39,7 +35,7 @@ public class HttpInvoker {
 
   /**
    * Make an HTTP POST method call to the given URL with the provided JSON payload. This method uses
-   * RestTemplate, which uses the system proxy automatically.
+   * useSystemProperties() option from HttpClientBuilder.
    *
    * @param url URL for POST method
    * @param jsonPayload Serialized JSON payload.

--- a/src/main/java/org/certificatetransparency/ctlog/comm/HttpLogClient.java
+++ b/src/main/java/org/certificatetransparency/ctlog/comm/HttpLogClient.java
@@ -154,7 +154,7 @@ public class HttpLogClient {
       methodPath = ADD_CHAIN_PATH;
     }
 
-    String response = postInvoker.makePostRequest(logUrl + methodPath, jsonPayload);
+    String response = postInvoker.makePostRequestAutoProxy(logUrl + methodPath, jsonPayload);
     return parseServerResponse(response);
   }
 

--- a/src/test/java/org/certificatetransparency/ctlog/comm/HttpLogClientTest.java
+++ b/src/test/java/org/certificatetransparency/ctlog/comm/HttpLogClientTest.java
@@ -206,7 +206,7 @@ public class HttpLogClientTest {
   @Test
   public void certificateSentToServer() throws IOException, CertificateException {
     HttpInvoker mockInvoker = mock(HttpInvoker.class);
-    when(mockInvoker.makePostRequest(eq("http://ctlog/add-chain"), Matchers.anyString()))
+    when(mockInvoker.makePostRequestAutoProxy(eq("http://ctlog/add-chain"), Matchers.anyString()))
         .thenReturn(JSON_RESPONSE);
 
     HttpLogClient client = new HttpLogClient("http://ctlog/", mockInvoker);


### PR DESCRIPTION
In the case where this module is run behind a network requiring a proxy, the current solution to obtain an SCT from a log server doesn't work.

This pull request features a new method, for the POST request, called `makePostRequestAutoProxy` which uses `RestTemplate` from **Spring Framework**. `RestTemplate` uses the configured system proxy (environment variable either `http_proxy`, `HTTP_PROXY`, `https_proxy` or `HTTPS_PROXY`) automatically.

