### PR TITLE
Update Travis builds from Oracle JDK 8 to JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 # Override the default installer; we don't want `mvn install` to run.
 install: true


### PR DESCRIPTION
Travis no longer supports Oracle JDK 8 so updating to the latest BCL-licensed version (11).