### PR TITLE
Explicitly mark the Java CT project as stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,10 @@
 # Certificate Transparency: Java Code
 
-![Maven badge](https://maven-badges.herokuapp.com/maven-central/org.certificate-transparency/ctlog/badge.png)
+This repository is no longer actively maintained.
+A CT client written in Go is available at
+https://github.com/google/certificate-transparency-go/.
 
-This repository holds Java code related to [Certificate
-Transparency](https://www.certificate-transparency.org/) (CT).
+See https://github.com/Babylonpartners/certificate-transparency-android for a
+Java CT client implementation.
 
-## Installation
-
-To install the library to your local Maven repository, simply execute:
-
-```shell
-git clone https://github.com/google/certificate-transparency-java
-cd certificate-transparency-java
-mvn install
-```
-
-To add this dependency to your project's POM:
-
-```xml
-<dependency>
-    <groupId>org.certificate-transparency</groupId>
-    <artifactId>ctlog</artifactId>
-    <version>0.1.0</version>
-    <scope>compile</scope>
-</dependency>
-```
-
-## Known Issues
-
-- Does not support Android. Alternatives exist for use on Android, such as:
-  - https://github.com/anonyome/certificate-transparency-android
-  - https://github.com/Babylonpartners/certificate-transparency-android
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Certificate Transparency: Java Code
 
 This repository is no longer actively maintained.
-A CT client written in Go is available at
-https://github.com/google/certificate-transparency-go/.
-
 See https://github.com/Babylonpartners/certificate-transparency-android for a
 Java CT client implementation.
 
+A CT client written in Go is available at
+https://github.com/google/certificate-transparency-go/.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Certificate Transparency: Java Code
 
 This repository is no longer actively maintained.
-See https://github.com/Babylonpartners/certificate-transparency-android for a
+See https://github.com/babylonhealth/certificate-transparency-android for a
 Java CT client implementation.
 
 A CT client written in Go is available at


### PR DESCRIPTION
Keeping this project alive isn't useful at this point. The community have created a more widely usable and more actively maintained Java client implementation.